### PR TITLE
Fix: Email/Password auth salt not being used in hash

### DIFF
--- a/auth/email-password/src/signup.ts
+++ b/auth/email-password/src/signup.ts
@@ -36,7 +36,7 @@ export default async (event: FunctionEvent<EventData>) => {
 
     // create password hash
     const salt = bcrypt.genSaltSync(SALT_ROUNDS)
-    const hash = await bcrypt.hash(password, SALT_ROUNDS)
+    const hash = await bcrypt.hash(password, salt)
 
     // create new user
     const userId = await createGraphcoolUser(api, email, hash)


### PR DESCRIPTION
The `bcrypt.hash` function was not using the generated salt value, so everybody was using `SALT_ROUNDS` only.